### PR TITLE
Andmebaasitabeli primaarvõti võib olla ka `UUID`-tüüpi.

### DIFF
--- a/Muutelugu.md
+++ b/Muutelugu.md
@@ -3,6 +3,10 @@ permalink: Muutelugu
 ---
 
 ## Muutelugu
+___12.2023___
+
+- Andmebaasitabeli primaarvõti võib olla ka `UUID`-tüüpi. [MFN 16.3](https://e-gov.github.io/MFN/#16.3)
+
 ___02\.05.2023___
 
 - Java fat jar-de nõue tunnistatud kehtetuks.  [MFN 18.6](https://e-gov.github.io/MFN/#18.6)

--- a/_data/Nouded.yml
+++ b/_data/Nouded.yml
@@ -188,7 +188,7 @@
       son: 'Ühest andmetabelist teise viitamisel tuleb kasutada välisvõtmeid (_foreign key_). Kõik välisvõtmed peavad olema indekseeritud mitteunikaalse indeksiga ja välisvõtmetena kirjeldatud.'
       sel: ''
     - nr: 3
-      son: 'Kõigis andmebaasi tabelites peab olema defineeritud `integer`-tüüpi primaarvõti, mis on surrogaatvõti. Primaarvõtmena ei tohi kasutada reaalse eluga seotud andmevälju.'
+      son: 'Kõigis andmebaasi tabelites peab olema defineeritud `integer`-tüüpi või `UUID`-tüüpi primaarvõti, mis on surrogaatvõti. Primaarvõtmena ei tohi kasutada reaalse eluga seotud andmevälju.'
       sel: ''
     - nr: 4
       son: 'Kõik primaarvõtmed (_primary key_) peavad olema indekseeritud unikaalse indeksiga.'


### PR DESCRIPTION
Teen ettepaneku lubada UUID-tüüpi primaarvõtmeid, sest need rahuldavad kõiki ülejäänud antud punkti nõudeid. 
Kuigi UUID väärtust saab väljendada täisarvuna, siis tasuks selle lubatavus selguse huvides eraldi ära mainida.